### PR TITLE
Set all export functions to protected

### DIFF
--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -848,7 +848,7 @@ class FindologicArticleModel
      *
      * @return string
      */
-    private function translateBooleanAsSnippet($status)
+    protected function translateBooleanAsSnippet($status)
     {
         if ($status) {
             $snippet = 'list/render_value/notified/yes';
@@ -859,7 +859,7 @@ class FindologicArticleModel
         return Shopware()->Snippets()->getNamespace('backend/notification/view/main')->get($snippet);
     }
 
-    private function isCrossSellingCategoryConfiguredForArticle()
+    protected function isCrossSellingCategoryConfiguredForArticle()
     {
         $crossSellingCategories = Shopware()->Config()->offsetGet('CrossSellingCategories');
         /** @var Category $category */


### PR DESCRIPTION
To be able to extend all the functionality in `ExtendFinSearchUnified`, you need to be able to call all the helper functions in `FindologicArticleModel`.