### PR TITLE
SW-402 Make Crossselling Categories compatible

### DIFF
--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -864,9 +864,19 @@ class FindologicArticleModel
         $crossSellingCategories = Shopware()->Config()->offsetGet('CrossSellingCategories');
         /** @var Category $category */
         foreach ($this->baseArticle->getCategories() as $category) {
-            if (in_array($category->getId(), $crossSellingCategories, true)) {
+            if (in_array($this->buildCategoryTree($category), $crossSellingCategories, true)) {
                 return true;
             }
         }
+        return false;
+    }
+
+    protected function buildCategoryTree($category)
+    {
+        if ($category === $this->baseCategory) {
+            return $category->getName();
+        }
+
+        return $this->buildCategoryTree($category->getParent()) . '>' . $category->getName();
     }
 }

--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -871,7 +871,7 @@ class FindologicArticleModel
         return false;
     }
 
-    protected function buildCategoryTree($category)
+    protected function buildCategoryTree(Category $category)
     {
         if ($category->getId() === $this->baseCategory->getId()) {
             return $category->getName();

--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -873,7 +873,7 @@ class FindologicArticleModel
 
     protected function buildCategoryTree($category)
     {
-        if ($category === $this->baseCategory) {
+        if ($category->getId() === $this->baseCategory->getId()) {
             return $category->getName();
         }
 

--- a/FinSearchUnified/Resources/config.xml
+++ b/FinSearchUnified/Resources/config.xml
@@ -50,7 +50,7 @@
     }).create();//new ]]>
             </store>
             <options>
-                <valueField>id</valueField>
+                <valueField>name</valueField>
                 <displayField>name</displayField>
                 <isCustomStore>true</isCustomStore>
                 <multiSelect>true</multiSelect>

--- a/FinSearchUnified/Tests/BusinessLogic/Models/FindologicArticleModelTest.php
+++ b/FinSearchUnified/Tests/BusinessLogic/Models/FindologicArticleModelTest.php
@@ -164,7 +164,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
         $this->assertEquals(get_class($findologicArticle), FindologicArticleModel::class);
     }
@@ -296,14 +296,14 @@ class FindologicArticleModelTest extends TestCase
         $baseCategory = new Category();
         $baseCategory->setId(100);
 
-        $article = $this->createTestProduct($articleConfiguration);
+        $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
-            $article,
+            $articleFromConfiguration,
             'ABCD0815',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -365,7 +365,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -402,7 +402,7 @@ class FindologicArticleModelTest extends TestCase
     public function testArticleWithSEOUrl(array $articleConfiguration, $expectedUrl)
     {
         $baseCategory = new Category();
-        $baseCategory->setId(5);
+        $baseCategory->setId(100);
 
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
@@ -419,7 +419,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -827,7 +827,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -895,7 +895,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -964,7 +964,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();
@@ -1054,7 +1054,7 @@ class FindologicArticleModelTest extends TestCase
             'ABCDABCDABCDABCDABCDABCDABCDABCD',
             [],
             [],
-            $baseCategory
+            $articleFromConfiguration->getCategories()->first()
         );
 
         $xmlArticle = $findologicArticle->getXmlRepresentation();

--- a/FinSearchUnified/Tests/BusinessLogic/Models/FindologicArticleModelTest.php
+++ b/FinSearchUnified/Tests/BusinessLogic/Models/FindologicArticleModelTest.php
@@ -154,9 +154,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testEmptySuppliersAreSkipped(array $articleConfiguration)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(100);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -293,9 +290,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testEmptyValue(array $articleConfiguration)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(100);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -355,9 +349,6 @@ class FindologicArticleModelTest extends TestCase
 
         $expectedKeywords = ["I'm a simple string", "\xC2\xBD"];
 
-        $baseCategory = new Category();
-        $baseCategory->setId(5);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -401,9 +392,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testArticleWithSEOUrl(array $articleConfiguration, $expectedUrl)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(100);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $shop = Manager::getResource('Shop')->getRepository()->find(1);
@@ -817,9 +805,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testEmptyValuesAreNotExported(array $articleConfiguration)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(5);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -885,9 +870,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testEmptyPropertyValue(array $articleConfiguration)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(5);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -954,9 +936,6 @@ class FindologicArticleModelTest extends TestCase
      */
     public function testEmptyAttributeValues(array $articleConfiguration)
     {
-        $baseCategory = new Category();
-        $baseCategory->setId(5);
-
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 
         $findologicArticle = $this->articleFactory->create(
@@ -1043,9 +1022,6 @@ class FindologicArticleModelTest extends TestCase
 
         $shop = Manager::getResource('Shop')->getRepository()->find($locale);
         Shopware()->Snippets()->setShop($shop);
-
-        $baseCategory = new Category();
-        $baseCategory->setId(5);
 
         $articleFromConfiguration = $this->createTestProduct($articleConfiguration);
 

--- a/FinSearchUnified/Tests/PluginTest.php
+++ b/FinSearchUnified/Tests/PluginTest.php
@@ -98,15 +98,15 @@ class PluginTest extends TestCase
                 'expectedCount' => 1
             ],
             'Article does not exist in cross-sell category configured' => [
-                'crossSellingCategories' => [5],
+                'crossSellingCategories' => ['Deutsch>Genusswelten'],
                 'expectedCount' => 1
             ],
             'Article exists in one of the cross-sell categories configured' => [
-                'crossSellingCategories' => [8, 9],
+                'crossSellingCategories' => ['Deutsch>Genusswelten', 'Deutsch>Wohnwelten'],
                 'expectedCount' => 0
             ],
             'Article exists in all of cross-sell categories configured' => [
-                'crossSellingCategories' => [8, 9, 10],
+                'crossSellingCategories' => ['Deutsch>Genusswelten', 'Deutsch>Wohnwelten', 'Deutsch>Beispiele'],
                 'expectedCount' => 0
             ],
         ];


### PR DESCRIPTION
In older versions of Shopware, the category name is saved instead of the ID.

Because of that, we need to check for the category name instead